### PR TITLE
Fix stale rootless notification after processing restarts

### DIFF
--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootlessAudioProcessorService.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootlessAudioProcessorService.kt
@@ -85,6 +85,8 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
     // Session management
     private lateinit var sessionManager: RootlessSessionManager
     private var sessionLossRetryCount = 0
+    @Volatile
+    private var notificationSessions: Array<IEffectSession> = emptyArray()
 
     // Idle detection
     private var isProcessorIdle = false
@@ -327,9 +329,11 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
             isProcessorIdle = sessionList.size == 0
             Timber.d("onSessionChanged: isProcessorIdle=$isProcessorIdle")
 
+            notificationSessions = sessionList.values.toTypedArray()
+
             ServiceNotificationHelper.pushServiceNotification(
                 this@RootlessAudioProcessorService,
-                sessionList.map { it.value }.toTypedArray()
+                notificationSessions
             )
         }
     }
@@ -459,7 +463,12 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
         // TODO Move all audio-related code to C++
         recorderThread = Thread {
             try {
-                ServiceNotificationHelper.pushServiceNotification(applicationContext, arrayOf())
+                // Rebuilding the processing pipeline must not overwrite the current
+                // session-aware notification with a false "idle" state.
+                ServiceNotificationHelper.pushServiceNotification(
+                    applicationContext,
+                    notificationSessions,
+                )
 
                 val floatBuffer = FloatArray(bufferSize)
                 val floatOutBuffer = FloatArray(bufferSize)


### PR DESCRIPTION
## Summary

Preserve the latest active effect sessions when the rootless audio processing pipeline is restarted.

Previously, `startRecording()` always updated the service notification with an empty session array. Sample-rate or audio-route changes could therefore overwrite a valid active-processing notification with “Audio processing idle.”

The service now caches the latest session list and reuses it when the processing pipeline is rebuilt.

## Testing

- Verified the notification remains active across processing-rate changes
- Tested with active Bluetooth playback
- All 16 rootless F-Droid unit tests pass
- Rootless debug APK builds successfully