### PR TITLE
Add sample-rate-specific convolver impulse responses

### DIFF
--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/PreferenceGroupFragment.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/PreferenceGroupFragment.kt
@@ -9,11 +9,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.XmlRes
+import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.Preference.SummaryProvider
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceScreen
 import androidx.recyclerview.widget.RecyclerView
+import me.timschneeberger.rootlessjamesdsp.MainApplication
 import me.timschneeberger.rootlessjamesdsp.R
 import me.timschneeberger.rootlessjamesdsp.activity.GraphicEqualizerActivity
 import me.timschneeberger.rootlessjamesdsp.activity.LiveprogEditorActivity
@@ -26,6 +28,8 @@ import me.timschneeberger.rootlessjamesdsp.preference.EqualizerPreference
 import me.timschneeberger.rootlessjamesdsp.preference.FileLibraryPreference
 import me.timschneeberger.rootlessjamesdsp.preference.MaterialSeekbarPreference
 import me.timschneeberger.rootlessjamesdsp.preference.SwitchPreferenceGroup
+import me.timschneeberger.rootlessjamesdsp.utils.AudioSampleRateDetector
+import me.timschneeberger.rootlessjamesdsp.utils.ConvolverSampleRateFiles
 import me.timschneeberger.rootlessjamesdsp.utils.Constants
 import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.registerLocalReceiver
 import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.sendLocalBroadcast
@@ -34,6 +38,7 @@ import me.timschneeberger.rootlessjamesdsp.utils.preferences.Preferences
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import timber.log.Timber
+import java.io.File
 import kotlin.math.roundToInt
 
 
@@ -41,10 +46,13 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
     private val prefsApp: Preferences.App by inject()
     private val eelParser = EelParser()
     private var recyclerView: RecyclerView? = null
+    private var reportedProcessingSampleRate: Int? = null
+    private var convolverStatusUpdater: (() -> Unit)? = null
 
     private val listener =
         SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
             requireContext().sendLocalBroadcast(Intent(Constants.ACTION_PREFERENCES_UPDATED))
+            convolverStatusUpdater?.invoke()
         }
 
     private val listenerApp =
@@ -56,10 +64,18 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
 
     private val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            if(intent?.action == Constants.ACTION_PRESET_LOADED) {
-                val id = this@PreferenceGroupFragment.id
-                Timber.d("Reloading group fragment for ${this@PreferenceGroupFragment.preferenceManager.sharedPreferencesName}")
-                (requireParentFragment() as DspFragment).restartFragment(id, cloneInstance(this@PreferenceGroupFragment))
+            when(intent?.action) {
+                Constants.ACTION_PRESET_LOADED -> {
+                    val id = this@PreferenceGroupFragment.id
+                    Timber.d("Reloading group fragment for ${this@PreferenceGroupFragment.preferenceManager.sharedPreferencesName}")
+                    (requireParentFragment() as DspFragment).restartFragment(id, cloneInstance(this@PreferenceGroupFragment))
+                }
+                Constants.ACTION_REPORT_SAMPLE_RATE -> {
+                    reportedProcessingSampleRate = intent
+                        .getFloatExtra(Constants.EXTRA_SAMPLE_RATE, 0f)
+                        .roundToInt()
+                    convolverStatusUpdater?.invoke()
+                }
             }
         }
     }
@@ -78,9 +94,13 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
         preferenceManager.sharedPreferencesMode = Context.MODE_MULTI_PROCESS
         addPreferencesFromResource(args.getInt(BUNDLE_XML_RES))
 
-        requireContext().registerLocalReceiver(receiver, IntentFilter(Constants.ACTION_PRESET_LOADED))
+        requireContext().registerLocalReceiver(receiver, IntentFilter().apply {
+            addAction(Constants.ACTION_PRESET_LOADED)
+            addAction(Constants.ACTION_REPORT_SAMPLE_RATE)
+        })
 
         when(args.getInt(BUNDLE_XML_RES)) {
+            R.xml.dsp_convolver_preferences -> setupConvolverSampleRateFiles()
             R.xml.dsp_compander_preferences -> {
                 findPreference<MaterialSeekbarPreference>(getString(R.string.key_compander_granularity))?.valueLabelOverride =
                     fun(it: Float): String {
@@ -200,6 +220,128 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
         prefsApp.registerOnSharedPreferenceChangeListener(listenerApp)
     }
 
+    private fun setupConvolverSampleRateFiles() {
+        val assignmentPreference = findPreference<Preference>(
+            getString(R.string.key_convolver_sample_rate_files)
+        ) ?: return
+        val filePreference = findPreference<FileLibraryPreference>(
+            getString(R.string.key_convolver_file)
+        ) ?: return
+        val processingPreference = findPreference<Preference>(
+            getString(R.string.key_convolver_processing_rate)
+        ) ?: return
+        val sharedPreferences = preferenceManager.sharedPreferences ?: return
+        val assignmentKey = getString(R.string.key_convolver_sample_rate_files)
+
+        fun assignments() = ConvolverSampleRateFiles.decode(
+            sharedPreferences.getString(assignmentKey, "").orEmpty()
+        )
+
+        fun processingRate(): Int = reportedProcessingSampleRate
+            ?: (requireActivity().application as MainApplication).engineSampleRate.roundToInt()
+
+        fun selectedImpulseResponse(rate: Int): String {
+            if (!sharedPreferences.getBoolean(getString(R.string.key_convolver_enable), false)) {
+                return getString(R.string.convolver_sample_rate_disabled)
+            }
+
+            val fallbackFile = filePreference.value.orEmpty()
+            val mappedFile = ConvolverSampleRateFiles.resolve(
+                sharedPreferences.getString(assignmentKey, "").orEmpty(),
+                rate,
+                fallbackFile,
+            )
+            val selectedFile = mappedFile.takeIf {
+                File(FileLibraryPreference.createFullPathCompat(requireContext(), it)).isFile
+            } ?: fallbackFile
+            return selectedFile.takeIf(String::isNotBlank)
+                ?.let { File(it).nameWithoutExtension }
+                ?: getString(R.string.convolver_sample_rate_no_file)
+        }
+
+        fun updateSummary() {
+            val count = assignments().size
+            val rate = processingRate()
+            processingPreference.summary = if (rate > 0) {
+                getString(
+                    R.string.convolver_processing_rate_status,
+                    ConvolverSampleRateFiles.formatKilohertz(rate),
+                    selectedImpulseResponse(rate),
+                )
+            } else {
+                getString(R.string.convolver_sample_rate_processing_inactive)
+            }
+            val assignmentsSummary = if (count == 0)
+                getString(R.string.convolver_sample_rate_files_summary)
+            else
+                getString(R.string.convolver_sample_rate_files_count, count)
+            assignmentPreference.summary = assignmentsSummary
+        }
+
+        convolverStatusUpdater = ::updateSummary
+
+        assignmentPreference.setOnPreferenceClickListener {
+            filePreference.refresh()
+            val assignedFiles = assignments()
+            val detectedRates = AudioSampleRateDetector.getOutputSampleRates(
+                requireContext(),
+            )
+            val sampleRates = (detectedRates + assignedFiles.keys)
+                .filter(ConvolverSampleRateFiles::isSupportedSampleRate)
+                .distinct()
+                .sorted()
+            val rateLabels = sampleRates.map { rate ->
+                val fileName = assignedFiles[rate]
+                    ?.let { File(it).nameWithoutExtension }
+                    ?: getString(R.string.convolver_sample_rate_unassigned)
+                getString(
+                    R.string.convolver_sample_rate_label,
+                    ConvolverSampleRateFiles.formatKilohertz(rate),
+                    fileName,
+                )
+            }.toTypedArray()
+
+            AlertDialog.Builder(requireContext())
+                .setTitle(R.string.convolver_sample_rate_files)
+                .setItems(rateLabels) { _, rateIndex ->
+                    val rate = sampleRates[rateIndex]
+                    val choices = arrayOf(getString(R.string.convolver_sample_rate_use_default)) +
+                        filePreference.entries.map(CharSequence::toString)
+
+                    AlertDialog.Builder(requireContext())
+                        .setTitle(
+                            getString(
+                                R.string.convolver_sample_rate_select_file,
+                                ConvolverSampleRateFiles.formatKilohertz(rate),
+                            )
+                        )
+                        .setItems(choices) { _, fileIndex ->
+                            val updatedAssignments = assignments().toMutableMap()
+                            if (fileIndex == 0) {
+                                updatedAssignments.remove(rate)
+                            } else {
+                                updatedAssignments[rate] =
+                                    filePreference.entryValues[fileIndex - 1].toString()
+                            }
+                            sharedPreferences.edit()
+                                .putString(
+                                    assignmentKey,
+                                    ConvolverSampleRateFiles.encode(updatedAssignments),
+                                )
+                                .apply()
+                            updateSummary()
+                        }
+                        .setNegativeButton(android.R.string.cancel, null)
+                        .show()
+                }
+                .setNegativeButton(android.R.string.cancel, null)
+                .show()
+            true
+        }
+
+        updateSummary()
+    }
+
     override fun onCreateRecyclerView(
         inflater: LayoutInflater,
         parent: ViewGroup,
@@ -218,6 +360,7 @@ class PreferenceGroupFragment : PreferenceFragmentCompat(), KoinComponent {
     }
 
     override fun onDestroy() {
+        convolverStatusUpdater = null
         super.onDestroy()
         requireContext().unregisterLocalReceiver(receiver)
         prefsApp.unregisterOnSharedPreferenceChangeListener(listener)

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspBaseEngine.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspBaseEngine.kt
@@ -14,6 +14,7 @@ import me.timschneeberger.rootlessjamesdsp.model.ParametricEqBandList
 import me.timschneeberger.rootlessjamesdsp.model.ProcessorMessage
 import me.timschneeberger.rootlessjamesdsp.preference.FileLibraryPreference
 import me.timschneeberger.rootlessjamesdsp.utils.BiquadUtils
+import me.timschneeberger.rootlessjamesdsp.utils.ConvolverSampleRateFiles
 import me.timschneeberger.rootlessjamesdsp.utils.Constants
 import me.timschneeberger.rootlessjamesdsp.utils.extensions.ContextExtensions.sendLocalBroadcast
 import timber.log.Timber
@@ -117,6 +118,7 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
             cache.select(Constants.PREF_CONVOLVER)
             val convolverEnabled = cache.get(R.string.key_convolver_enable, false)
             val convolverFile = cache.get(R.string.key_convolver_file, "")
+            val convolverSampleRateFiles = cache.get(R.string.key_convolver_sample_rate_files, "")
             val convolverAdvImp = cache.get(R.string.key_convolver_adv_imp, Constants.DEFAULT_CONVOLVER_ADVIMP)
             val convolverMode = cache.get(R.string.key_convolver_mode, "0").toInt()
 
@@ -137,7 +139,17 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
                     Constants.PREF_TUBE -> setVacuumTube(tubeEnabled, tubeDrive)
                     Constants.PREF_DDC -> setVdc(ddcEnabled, ddcFile)
                     Constants.PREF_LIVEPROG -> setLiveprog(liveProgEnabled, liveprogFile)
-                    Constants.PREF_CONVOLVER -> setConvolver(convolverEnabled, convolverFile, convolverMode, convolverAdvImp)
+                    Constants.PREF_CONVOLVER -> {
+                        val mappedFile = ConvolverSampleRateFiles.resolve(
+                            convolverSampleRateFiles,
+                            sampleRate.toInt(),
+                            convolverFile,
+                        )
+                        val selectedFile = mappedFile.takeIf {
+                            File(FileLibraryPreference.createFullPathCompat(context, it)).isFile
+                        } ?: convolverFile
+                        setConvolver(convolverEnabled, selectedFile, convolverMode, convolverAdvImp)
+                    }
                     else -> true
                 }
 
@@ -203,10 +215,11 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
     fun setConvolver(enable: Boolean, impulseResponsePath: String, optimizationMode: Int, waveEditStr: String): Boolean
     {
         val path = FileLibraryPreference.createFullPathCompat(context, impulseResponsePath)
+        val targetSampleRate = sampleRate.toInt()
 
         // Handle disabled state before everything else
         if(!enable || !File(path).exists() || File(path).isDirectory) {
-            setConvolverInternal(false, FloatArray(0), 0, 0, 0)
+            setConvolverInternal(false, FloatArray(0), 0, 0, 0, targetSampleRate)
             return true
         }
 
@@ -234,7 +247,7 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
         val info = IntArray(4)
         val imp = JdspImpResToolbox.ReadImpulseResponseToFloat(
             path,
-            sampleRate.toInt(),
+            targetSampleRate,
             info,
             optimizationMode,
             advSetting
@@ -242,7 +255,7 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
 
         if(imp == null) {
             Timber.e("setConvolver: Failed to read IR")
-            setConvolverInternal(false, FloatArray(0), 0, 0, 0)
+            setConvolverInternal(false, FloatArray(0), 0, 0, 0, targetSampleRate)
             callbacks?.onConvolverParseError(ProcessorMessage.ConvolverErrorCode.Corrupted)
             return false
         }
@@ -250,7 +263,7 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
         // check frame count
         if(info[1] == 0) {
             Timber.e("setConvolver: IR has no frames")
-            setConvolverInternal(false, FloatArray(0), 0, 0, 0)
+            setConvolverInternal(false, FloatArray(0), 0, 0, 0, targetSampleRate)
             callbacks?.onConvolverParseError(ProcessorMessage.ConvolverErrorCode.NoFrames)
             return false
         }
@@ -261,7 +274,7 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
             callbacks?.onConvolverParseError(ProcessorMessage.ConvolverErrorCode.AdvParamsInvalid)
         }
 
-        return setConvolverInternal(true, imp, info[0], info[1], info[2])
+        return setConvolverInternal(true, imp, info[0], info[1], info[2], targetSampleRate)
     }
 
     fun setGraphicEq(enable: Boolean, bands: String): Boolean
@@ -398,7 +411,14 @@ abstract class JamesDspBaseEngine(val context: Context, val callbacks: JamesDspW
     protected abstract fun setMultiEqualizerInternal(enable: Boolean, filterType: Int, interpolationMode: Int, bands: DoubleArray): Boolean
     protected abstract fun setCompanderInternal(enable: Boolean, timeConstant: Float, granularity: Int, tfTransforms: Int, bands: DoubleArray): Boolean
     protected abstract fun setVdcInternal(enable: Boolean, vdc: String): Boolean
-    protected abstract fun setConvolverInternal(enable: Boolean, impulseResponse: FloatArray, irChannels: Int, irFrames: Int, irCrc: Int): Boolean
+    protected abstract fun setConvolverInternal(
+        enable: Boolean,
+        impulseResponse: FloatArray,
+        irChannels: Int,
+        irFrames: Int,
+        irCrc: Int,
+        irSampleRate: Int,
+    ): Boolean
     protected abstract fun setGraphicEqInternal(enable: Boolean, bands: String): Boolean
     protected abstract fun setLiveprogInternal(enable: Boolean, name: String, script: String): Boolean
 

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspLocalEngine.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspLocalEngine.kt
@@ -149,7 +149,8 @@ class JamesDspLocalEngine(context: Context, callbacks: JamesDspWrapper.JamesDspC
         impulseResponse: FloatArray,
         irChannels: Int,
         irFrames: Int,
-        irCrc: Int
+        irCrc: Int,
+        irSampleRate: Int,
     ): Boolean {
         return JamesDspWrapper.setConvolver(handle, enable, impulseResponse, irChannels, irFrames)
     }

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspRemoteEngine.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/interop/JamesDspRemoteEngine.kt
@@ -31,6 +31,8 @@ class JamesDspRemoteEngine(
     callbacks: JamesDspWrapper.JamesDspCallbacks? = null,
 ) : JamesDspBaseEngine(context, callbacks) {
 
+    private var convolverSampleRate = 0
+
     private val broadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             when (intent.action) {
@@ -218,8 +220,11 @@ class JamesDspRemoteEngine(
         impulseResponse: FloatArray,
         irChannels: Int,
         irFrames: Int,
-        irCrc: Int
+        irCrc: Int,
+        irSampleRate: Int,
     ): Boolean {
+
+        convolverSampleRate = irSampleRate
 
         val prevCrc = this.convolverHash
 
@@ -230,6 +235,16 @@ class JamesDspRemoteEngine(
         }
 
         return effect.setParameter(1205, enable.toShort()) == AudioEffect.SUCCESS
+    }
+
+    fun reloadConvolverIfSampleRateChanged() {
+        val currentSampleRate = sampleRate.toInt()
+        if (currentSampleRate > 0 && currentSampleRate != convolverSampleRate) {
+            Timber.i(
+                "Convolver sample rate changed from ${convolverSampleRate}Hz to ${currentSampleRate}Hz"
+            )
+            syncWithPreferences(arrayOf(Constants.PREF_CONVOLVER))
+        }
     }
 
     override fun setGraphicEqInternal(enable: Boolean, bands: String): Boolean {

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootAudioProcessorService.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootAudioProcessorService.kt
@@ -6,8 +6,11 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.media.AudioManager
+import android.media.AudioPlaybackConfiguration
 import android.media.audiofx.AudioEffect
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import androidx.core.content.getSystemService
 import androidx.lifecycle.Observer
 import androidx.lifecycle.asLiveData
@@ -21,6 +24,7 @@ import me.timschneeberger.rootlessjamesdsp.MainApplication
 import me.timschneeberger.rootlessjamesdsp.R
 import me.timschneeberger.rootlessjamesdsp.interop.JamesDspRemoteEngine
 import me.timschneeberger.rootlessjamesdsp.model.IEffectSession
+import me.timschneeberger.rootlessjamesdsp.model.root.RemoteEffectSession
 import me.timschneeberger.rootlessjamesdsp.model.room.AppBlocklistDatabase
 import me.timschneeberger.rootlessjamesdsp.model.room.AppBlocklistRepository
 import me.timschneeberger.rootlessjamesdsp.model.room.BlockedApp
@@ -42,6 +46,14 @@ class RootAudioProcessorService : BaseAudioProcessorService(), KoinComponent,
     // System services
     private lateinit var notificationManager: NotificationManager
     private lateinit var audioManager: AudioManager
+
+    private val audioPlaybackCallback = object : AudioManager.AudioPlaybackCallback() {
+        override fun onPlaybackConfigChanged(configs: MutableList<AudioPlaybackConfiguration>?) {
+            app.rootSessionDatabase.sessionList.values.forEach { session ->
+                (session as? RemoteEffectSession)?.effect?.reloadConvolverIfSampleRateChanged()
+            }
+        }
+    }
 
     // Termination flags
     private var isServiceDisposing = false
@@ -84,6 +96,10 @@ class RootAudioProcessorService : BaseAudioProcessorService(), KoinComponent,
         // Get reference to system services
         audioManager = getSystemService<AudioManager>()!!
         notificationManager = getSystemService<NotificationManager>()!!
+        audioManager.registerAudioPlaybackCallback(
+            audioPlaybackCallback,
+            Handler(Looper.getMainLooper()),
+        )
 
         // Setup database observer
         blockedApps.observeForever(blockedAppObserver)
@@ -173,6 +189,7 @@ class RootAudioProcessorService : BaseAudioProcessorService(), KoinComponent,
 
         // Unregister database observer
         blockedApps.removeObserver(blockedAppObserver)
+        audioManager.unregisterAudioPlaybackCallback(audioPlaybackCallback)
 
         // Notify app about service termination and unregister
         sendLocalBroadcast(Intent(Constants.ACTION_SERVICE_STOPPED))

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/AudioSampleRateDetector.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/AudioSampleRateDetector.kt
@@ -1,0 +1,102 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.content.getSystemService
+import timber.log.Timber
+
+/** Detects output sample rates that can have dedicated convolver impulse responses. */
+object AudioSampleRateDetector {
+
+    fun getOutputSampleRates(context: Context): List<Int> {
+        val audioManager = context.getSystemService<AudioManager>()
+        val nativeRate = audioManager?.let(::getActiveOutputSampleRate) ?: 0
+
+        val mixerRates = if (audioManager != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            getAndroid14MixerRates(audioManager)
+        } else {
+            emptyList()
+        }
+
+        return normalizeSampleRates(mixerRates, nativeRate)
+    }
+
+    fun getActiveOutputSampleRate(audioManager: AudioManager): Int {
+        val preferredMixerRate = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            getAndroid14PreferredMixerRate(audioManager)
+        } else {
+            0
+        }
+        val nativeRate = audioManager
+            .getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
+            ?.toIntOrNull()
+            ?: 0
+
+        return preferredMixerRate.takeIf(::isSupportedProcessingRate)
+            ?: nativeRate.takeIf(::isSupportedProcessingRate)
+            ?: DEFAULT_SAMPLE_RATE
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getAndroid14MixerRates(audioManager: AudioManager): List<Int> {
+        return try {
+            val mediaAttributes = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .build()
+
+            audioManager.getAudioDevicesForAttributes(mediaAttributes)
+                .flatMap { device ->
+                    audioManager.getSupportedMixerAttributes(device).map { it.format.sampleRate } +
+                        device.sampleRates.toList()
+                }
+        } catch (exception: RuntimeException) {
+            // Some vendor audio services expose the API but reject the query.
+            Timber.w(exception, "Failed to query Android 14 mixer sample rates")
+            emptyList()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getAndroid14PreferredMixerRate(audioManager: AudioManager): Int {
+        return try {
+            val mediaAttributes = AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .build()
+
+            audioManager.getAudioDevicesForAttributes(mediaAttributes)
+                .firstNotNullOfOrNull { device ->
+                    audioManager.getPreferredMixerAttributes(mediaAttributes, device)
+                        ?.format
+                        ?.sampleRate
+                        ?.takeIf(::isSupportedProcessingRate)
+                } ?: 0
+        } catch (exception: RuntimeException) {
+            Timber.w(exception, "Failed to query Android 14 preferred mixer sample rate")
+            0
+        }
+    }
+
+    internal fun normalizeSampleRates(
+        detectedRates: Collection<Int>,
+        fallbackRate: Int,
+    ): List<Int> {
+        val rates = detectedRates
+            .filter(::isSupportedProcessingRate)
+            .toSortedSet()
+        if (rates.isNotEmpty()) return rates.toList()
+
+        return listOf(
+            fallbackRate.takeIf(::isSupportedProcessingRate) ?: DEFAULT_SAMPLE_RATE
+        )
+    }
+
+    internal fun isSupportedProcessingRate(rate: Int) =
+        rate in MIN_SAMPLE_RATE..MAX_SAMPLE_RATE
+
+    private const val DEFAULT_SAMPLE_RATE = 48_000
+    private const val MIN_SAMPLE_RATE = 1
+    private const val MAX_SAMPLE_RATE = 384_000
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/ConvolverSampleRateFiles.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/ConvolverSampleRateFiles.kt
@@ -1,0 +1,62 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import timber.log.Timber
+
+/** Serialization and lookup for sample-rate-specific impulse response files. */
+object ConvolverSampleRateFiles {
+
+    fun decode(value: String): Map<Int, String> {
+        if (value.isBlank()) return emptyMap()
+
+        return try {
+            Json.parseToJsonElement(value).jsonObject.entries.mapNotNull { (rate, path) ->
+                val sampleRate = rate.toIntOrNull() ?: return@mapNotNull null
+                val filePath = path.jsonPrimitive.content
+                if (isSupportedSampleRate(sampleRate) && filePath.isNotBlank()) {
+                    sampleRate to filePath
+                } else {
+                    null
+                }
+            }.toMap()
+        } catch (exception: Exception) {
+            Timber.w(exception, "Invalid convolver sample-rate file mapping")
+            emptyMap()
+        }
+    }
+
+    fun encode(files: Map<Int, String>): String {
+        return JsonObject(
+            files
+                .filter { (rate, path) ->
+                    isSupportedSampleRate(rate) && path.isNotBlank()
+                }
+                .toSortedMap()
+                .mapKeys { it.key.toString() }
+                .mapValues { JsonPrimitive(it.value) }
+        ).toString()
+    }
+
+    fun resolve(value: String, sampleRate: Int, fallbackFile: String): String {
+        return decode(value)[sampleRate] ?: fallbackFile
+    }
+
+    fun formatKilohertz(sampleRate: Int): String {
+        val whole = sampleRate / 1_000
+        val fraction = (sampleRate % 1_000)
+            .toString()
+            .padStart(3, '0')
+            .trimEnd('0')
+        return if (fraction.isEmpty()) whole.toString() else "$whole.$fraction"
+    }
+
+    fun isSupportedSampleRate(sampleRate: Int): Boolean =
+        sampleRate in MIN_SAMPLE_RATE..MAX_SAMPLE_RATE
+
+    private const val MIN_SAMPLE_RATE = 1
+    private const val MAX_SAMPLE_RATE = 192_000
+}

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -118,6 +118,8 @@
 
     <string name="key_convolver_enable" translatable="false">convolver_enable</string>
     <string name="key_convolver_file" translatable="false">convolver_file</string>
+    <string name="key_convolver_sample_rate_files" translatable="false">convolver_sample_rate_files</string>
+    <string name="key_convolver_processing_rate" translatable="false">convolver_processing_rate</string>
     <string name="key_convolver_mode" translatable="false">convolver_mode</string>
     <string name="key_convolver_adv_imp" translatable="false">convolver_adv_imp</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -181,6 +181,19 @@
 
     <string name="convolver_enable">Convolver</string>
     <string name="convolver_impulse">Impulse response</string>
+    <string name="convolver_sample_rate_files">Sample-rate impulse responses</string>
+    <string name="convolver_sample_rate_files_summary">Assign a different impulse response to each output sample rate</string>
+    <string name="convolver_sample_rate_files_count">%1$d sample-rate assignments</string>
+    <string name="convolver_processing_rate">Current processing</string>
+    <string name="convolver_processing_rate_status">%1$s kHz • Selected IR: %2$s</string>
+    <string name="convolver_sample_rate_select_file">Impulse response for %1$s kHz</string>
+    <string name="convolver_sample_rate_use_default">None (use default impulse response)</string>
+    <string name="convolver_sample_rate_unassigned">None (default)</string>
+    <string name="convolver_sample_rate_processing_status">Processing: %1$s kHz • Selected IR: %2$s</string>
+    <string name="convolver_sample_rate_processing_inactive">Processing inactive</string>
+    <string name="convolver_sample_rate_label">%1$s kHz - %2$s</string>
+    <string name="convolver_sample_rate_disabled">Convolver disabled</string>
+    <string name="convolver_sample_rate_no_file">No impulse response</string>
     <string name="convolver_advanced_editing">Advanced waveform editing</string>
     <string name="convolver_convolution_mode">Impulse response optimization</string>
     <string name="convolver_convolution_mode_original">Original</string>

--- a/app/src/main/res/xml/dsp_convolver_preferences.xml
+++ b/app/src/main/res/xml/dsp_convolver_preferences.xml
@@ -15,6 +15,17 @@
             app:useSimpleSummaryProvider="false"
             app:type="Convolver"
             app:iconSpaceReserved="false"/>
+        <Preference
+            android:key="@string/key_convolver_sample_rate_files"
+            android:title="@string/convolver_sample_rate_files"
+            android:summary="@string/convolver_sample_rate_files_summary"
+            app:iconSpaceReserved="false" />
+        <Preference
+            android:key="@string/key_convolver_processing_rate"
+            android:title="@string/convolver_processing_rate"
+            android:summary="@string/convolver_sample_rate_processing_inactive"
+            android:selectable="false"
+            app:iconSpaceReserved="false" />
         <ListPreference
             android:defaultValue="0"
             android:dialogTitle="@string/convolver_convolution_mode"

--- a/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/AudioSampleRateDetectorTest.kt
+++ b/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/AudioSampleRateDetectorTest.kt
@@ -1,0 +1,55 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AudioSampleRateDetectorTest {
+
+    @Test
+    fun `detected mixer rates are sorted and retained`() {
+        assertEquals(
+            listOf(44_100, 48_000, 96_000, 192_000),
+            AudioSampleRateDetector.normalizeSampleRates(
+                detectedRates = listOf(48_000, 96_000, 44_100, 192_000),
+                fallbackRate = 48_000,
+            )
+        )
+    }
+
+    @Test
+    fun `native rate is not added to reported mixer capabilities`() {
+        assertEquals(
+            listOf(96_000),
+            AudioSampleRateDetector.normalizeSampleRates(
+                detectedRates = listOf(96_000),
+                fallbackRate = 48_000,
+            )
+        )
+    }
+
+    @Test
+    fun `invalid rates are ignored and default is always available`() {
+        assertEquals(
+            listOf(48_000),
+            AudioSampleRateDetector.normalizeSampleRates(
+                detectedRates = listOf(-1, 0, 384_001, 768_000),
+                fallbackRate = 0,
+            )
+        )
+    }
+
+    @Test
+    fun `every detected rate through 384 kHz is retained`() {
+        val detectedRates = listOf(
+            8_000, 11_025, 12_000, 16_000, 22_050, 24_000, 32_000,
+            44_100, 48_000, 64_000, 88_200, 96_000, 176_400, 192_000, 384_000,
+        )
+
+        val result = AudioSampleRateDetector.normalizeSampleRates(
+            detectedRates = detectedRates,
+            fallbackRate = 48_000,
+        )
+
+        assertEquals(detectedRates.toSet(), result.toSet())
+    }
+}

--- a/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/ConvolverSampleRateFilesTest.kt
+++ b/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/ConvolverSampleRateFilesTest.kt
@@ -1,0 +1,77 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ConvolverSampleRateFilesTest {
+
+    @Test
+    fun `sample rates are formatted accurately in kilohertz`() {
+        assertEquals("11.025", ConvolverSampleRateFiles.formatKilohertz(11_025))
+        assertEquals("44.1", ConvolverSampleRateFiles.formatKilohertz(44_100))
+        assertEquals("192", ConvolverSampleRateFiles.formatKilohertz(192_000))
+        assertEquals("192", ConvolverSampleRateFiles.formatKilohertz(192_000))
+    }
+
+    @Test
+    fun `assignments through 192 kHz are retained and higher rates are rejected`() {
+        val encoded = ConvolverSampleRateFiles.encode(
+            mapOf(192_000 to "Convolver/192.wav", 384_000 to "Convolver/384.wav")
+        )
+
+        assertEquals(
+            mapOf(192_000 to "Convolver/192.wav"),
+            ConvolverSampleRateFiles.decode(encoded),
+        )
+        assertEquals(
+            "Convolver/default.wav",
+            ConvolverSampleRateFiles.resolve(
+                "{\"384000\":\"Convolver/384.wav\"}",
+                384_000,
+                "Convolver/default.wav",
+            ),
+        )
+    }
+
+    @Test
+    fun `assignments survive serialization`() {
+        val assignments = mapOf(
+            44_100 to "Convolver/room 44.wav",
+            48_000 to "Convolver/room 48.wav",
+            96_000 to "Convolver/room 96.wav",
+        )
+
+        assertEquals(
+            assignments,
+            ConvolverSampleRateFiles.decode(ConvolverSampleRateFiles.encode(assignments)),
+        )
+    }
+
+    @Test
+    fun `exact sample rate selects its assigned file`() {
+        val encoded = ConvolverSampleRateFiles.encode(
+            mapOf(44_100 to "Convolver/44.wav", 48_000 to "Convolver/48.wav")
+        )
+
+        assertEquals(
+            "Convolver/44.wav",
+            ConvolverSampleRateFiles.resolve(encoded, 44_100, "Convolver/default.wav"),
+        )
+        assertEquals(
+            "Convolver/48.wav",
+            ConvolverSampleRateFiles.resolve(encoded, 48_000, "Convolver/default.wav"),
+        )
+    }
+
+    @Test
+    fun `unassigned sample rate uses default file`() {
+        val encoded = ConvolverSampleRateFiles.encode(
+            mapOf(48_000 to "Convolver/48.wav")
+        )
+
+        assertEquals(
+            "Convolver/default.wav",
+            ConvolverSampleRateFiles.resolve(encoded, 96_000, "Convolver/default.wav"),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Add exact sample-rate-specific impulse response assignments for the convolver while preserving the existing impulse response as the fallback.

Users can assign an IR to each detected processing rate through 192 kHz. Selecting **None** removes that rate's assignment, so unassigned rates and processing above 192 kHz continue to use the normal fallback IR.

## Implementation

- detects available output rates, including Android 14 mixer attributes
- serializes exact rate-to-file assignments
- resolves the assigned IR whenever the engine synchronizes its convolver settings
- reloads root-mode convolution when the processing rate changes
- displays the current processing rate and selected IR
- supports both root and rootless engines

## Testing

- assignment serialization, exact matching, fallback behavior, and rate filtering are unit tested
- all 16 rootless F-Droid unit tests pass
- rootless debug APK builds successfully
- tested with Bluetooth playback and a FiiO BTR7 USB DAC

## Rate policy

Dedicated IR assignments are limited to 192 kHz. The processing engine may run at a higher hardware rate, but those rates intentionally use the fallback IR.