### PR TITLE
Add dynamic rootless processing and USB output rates

### DIFF
--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/settings/SettingsAudioFormatFragment.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/fragment/settings/SettingsAudioFormatFragment.kt
@@ -28,6 +28,9 @@ import timber.log.Timber
 class SettingsAudioFormatFragment : SettingsBaseFragment() {
 
     private val encoding by lazy { findPreference<ListPreference>(getString(R.string.key_audioformat_encoding)) }
+    private val rootlessUsbRateMode by lazy {
+        findPreference<ListPreference>(getString(R.string.key_audioformat_rootless_usb_rate_mode))
+    }
     private val bufferSize by lazy { findPreference<MaterialSeekbarPreference>(getString(R.string.key_audioformat_buffersize)) }
     private val legacyMode by lazy { findPreference<MaterialSwitchPreference>(getString(R.string.key_audioformat_processing)) }
     private val enhancedMode by lazy { findPreference<MaterialSwitchPreference>(getString(R.string.key_audioformat_enhanced_processing)) }
@@ -115,6 +118,11 @@ class SettingsAudioFormatFragment : SettingsBaseFragment() {
             true
         }
         encoding?.setOnPreferenceChangeListener { _, _ ->
+            context?.sendLocalBroadcast(Intent(Constants.ACTION_SERVICE_HARD_REBOOT_CORE))
+            true
+        }
+        rootlessUsbRateMode?.isVisible = isRootless()
+        rootlessUsbRateMode?.setOnPreferenceChangeListener { _, _ ->
             context?.sendLocalBroadcast(Intent(Constants.ACTION_SERVICE_HARD_REBOOT_CORE))
             true
         }

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootlessAudioProcessorService.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/service/RootlessAudioProcessorService.kt
@@ -10,8 +10,13 @@ import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
+import android.media.AudioDeviceCallback
+import android.media.AudioDeviceInfo
 import android.media.AudioFormat
 import android.media.AudioManager
+import android.media.AudioMixerAttributes
+import android.media.AudioPlaybackConfiguration
+import android.media.AudioPlaybackConfigurationHidden
 import android.media.AudioPlaybackCaptureConfiguration
 import android.media.AudioRecord
 import android.media.AudioTrack
@@ -23,11 +28,13 @@ import android.os.Looper
 import android.os.Process
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
-import androidx.core.math.MathUtils.clamp
 import androidx.lifecycle.Observer
 import androidx.lifecycle.asLiveData
+import dev.rikka.tools.refine.Refine
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import me.timschneeberger.rootlessjamesdsp.BuildConfig
 import me.timschneeberger.rootlessjamesdsp.R
 import me.timschneeberger.rootlessjamesdsp.flavor.CrashlyticsImpl
@@ -44,6 +51,9 @@ import me.timschneeberger.rootlessjamesdsp.session.rootless.RootlessSessionDatab
 import me.timschneeberger.rootlessjamesdsp.session.rootless.RootlessSessionManager
 import me.timschneeberger.rootlessjamesdsp.session.rootless.SessionRecordingPolicyManager
 import me.timschneeberger.rootlessjamesdsp.utils.Constants
+import me.timschneeberger.rootlessjamesdsp.utils.ActivePlaybackSampleRateDetector
+import me.timschneeberger.rootlessjamesdsp.utils.AudioSampleRateDetector
+import me.timschneeberger.rootlessjamesdsp.utils.UsbHardwareSampleRateDetector
 import me.timschneeberger.rootlessjamesdsp.utils.Constants.ACTION_PREFERENCES_UPDATED
 import me.timschneeberger.rootlessjamesdsp.utils.Constants.ACTION_SAMPLE_RATE_UPDATED
 import me.timschneeberger.rootlessjamesdsp.utils.Constants.ACTION_SERVICE_HARD_REBOOT_CORE
@@ -62,6 +72,8 @@ import me.timschneeberger.rootlessjamesdsp.utils.sdkAbove
 import org.koin.android.ext.android.inject
 import timber.log.Timber
 import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 
 @RequiresApi(Build.VERSION_CODES.Q)
@@ -71,6 +83,75 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
     private lateinit var notificationManager: NotificationManager
     private lateinit var audioManager: AudioManager
 
+    private val sampleRatePlaybackCallback = object : AudioManager.AudioPlaybackCallback() {
+        override fun onPlaybackConfigChanged(configs: MutableList<AudioPlaybackConfiguration>?) {
+            if (!isRunning) return
+
+            if (isUsbOutputConnected() && followUsbHardwareRate()) {
+                applicationScope.launch(Dispatchers.IO) {
+                    val sourceRate = ActivePlaybackSampleRateDetector.detect(
+                        this@RootlessAudioProcessorService,
+                        Process.myUid(),
+                    )
+                    mainHandler.post {
+                        if (sourceRate > 0 && sourceRate != lastUsbSourceSampleRate) {
+                            lastUsbSourceSampleRate = sourceRate
+                            scheduleUsbHardwareRateReconfiguration()
+                        }
+                    }
+                }
+                return
+            }
+
+            val generation = ++sampleRateDetectionGeneration
+            val callbackRate = detectActiveContentSampleRate(configs)
+            if (callbackRate > 0) {
+                applyActiveContentSampleRate(callbackRate)
+                return
+            }
+
+            applicationScope.launch(Dispatchers.IO) {
+                val dumpRate = ActivePlaybackSampleRateDetector.detect(
+                    this@RootlessAudioProcessorService,
+                    Process.myUid(),
+                )
+                mainHandler.post {
+                    if (generation == sampleRateDetectionGeneration && isRunning) {
+                        applyActiveContentSampleRate(dumpRate)
+                    }
+                }
+            }
+        }
+    }
+    private val usbRouteRestart = Runnable {
+        if (isRunning && !isProcessorDisposing && !isServiceDisposing) {
+            if (isUsbOutputConnected() && followUsbHardwareRate()) {
+                Timber.i("USB audio route changed; detecting physical hardware rate")
+                scheduleUsbHardwareRateReconfiguration()
+            } else {
+                Timber.i("USB audio route removed; rebuilding normal output")
+                restartRecording()
+            }
+        }
+    }
+    private val usbAudioDeviceCallback = object : AudioDeviceCallback() {
+        override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
+            if (addedDevices.none(::isUsbAudioDevice)) return
+            mainHandler.removeCallbacks(usbRouteRestart)
+            // USB profiles are populated asynchronously after the device-added callback.
+            mainHandler.postDelayed(usbRouteRestart, USB_ROUTE_SETTLE_DELAY_MS)
+        }
+
+        override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+            if (removedDevices.none(::isUsbAudioDevice)) return
+            activeUsbHardwareSampleRate = 0
+            mainHandler.removeCallbacks(usbRouteRestart)
+            mainHandler.post(usbRouteRestart)
+        }
+    }
+    private var preferredMixerAttributesListener:
+        AudioManager.OnPreferredMixerAttributesChangedListener? = null
+
     // Media projection token
     private var mediaProjection: MediaProjection? = null
     private var mediaProjectionStartIntent: Intent? = null
@@ -78,6 +159,14 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
     // Processing
     private var recreateRecorderRequested = false
     private var recorderThread: Thread? = null
+    private var activeContentSampleRate = 0
+    private var activeUsbHardwareSampleRate = 0
+    private var lastUsbSourceSampleRate = 0
+    private var usbHardwareRateReconfigurationPending = false
+    private var sampleRateDetectionGeneration = 0
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var preferredUsbMixerDevice: AudioDeviceInfo? = null
+    private var preferredUsbMixerAudioAttributes: AudioAttributes? = null
     private lateinit var engine: JamesDspLocalEngine
     private val isRunning: Boolean
         get() = recorderThread != null
@@ -130,6 +219,14 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
         // Setup core engine
         engine = JamesDspLocalEngine(this, ProcessorMessageHandler())
         engine.syncWithPreferences()
+        audioManager.registerAudioPlaybackCallback(
+            sampleRatePlaybackCallback,
+            Handler(Looper.getMainLooper()),
+        )
+        audioManager.registerAudioDeviceCallback(usbAudioDeviceCallback, mainHandler)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            registerPreferredMixerAttributesListener()
+        }
 
         // Setup general-purpose broadcast receiver
         val filter = IntentFilter()
@@ -222,6 +319,9 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
 
         // Stop recording and release engine
         stopRecording()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            clearPreferredUsbMixer()
+        }
         engine.close()
 
         // Stop foreground service
@@ -232,6 +332,12 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
 
         // Unregister database observer
         blockedApps.removeObserver(blockedAppObserver)
+        audioManager.unregisterAudioPlaybackCallback(sampleRatePlaybackCallback)
+        audioManager.unregisterAudioDeviceCallback(usbAudioDeviceCallback)
+        mainHandler.removeCallbacks(usbRouteRestart)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            unregisterPreferredMixerAttributesListener()
+        }
 
         // Unregister receivers and release resources
         unregisterLocalReceiver(broadcastReceiver)
@@ -419,20 +525,26 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
         }
 
         // Load preferences
-        val encoding = AudioEncoding.fromInt(
+        val requestedEncoding = AudioEncoding.fromInt(
             preferences.get<String>(R.string.key_audioformat_encoding).toIntOrNull() ?: 1
         )
+        val sampleRate = determineSamplingRate()
+        val requestedEncodingFormat = when (requestedEncoding) {
+            AudioEncoding.PcmShort -> AudioFormat.ENCODING_PCM_16BIT
+            else -> AudioFormat.ENCODING_PCM_FLOAT
+        }
+        val outputFormat = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            configurePreferredUsbMixer(sampleRate, requestedEncodingFormat)
+        } else {
+            null
+        } ?: buildOutputAudioFormat(requestedEncodingFormat, sampleRate)
+        val encodingFormat = requestedEncodingFormat
+        val encoding = requestedEncoding
         val bufferSize = preferences.get<Float>(R.string.key_audioformat_buffersize).toInt()
         val bufferSizeBytes = when (encoding) {
             AudioEncoding.PcmFloat -> bufferSize * Float.SIZE_BYTES
             else -> bufferSize * Short.SIZE_BYTES
         }
-        val encodingFormat = when (encoding) {
-            AudioEncoding.PcmShort -> AudioFormat.ENCODING_PCM_16BIT
-            else -> AudioFormat.ENCODING_PCM_FLOAT
-        }
-        val sampleRate = clamp(determineSamplingRate(), 44100, 48000)
-
         Timber.i("Sample rate: $sampleRate; Encoding: ${encoding.name}; " +
                 "Buffer size: $bufferSize; Buffer size (bytes): $bufferSizeBytes ; " +
                 "HAL buffer size (bytes): ${determineBufferSize()}")
@@ -442,7 +554,10 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
         val track: AudioTrack
         try {
             recorder = buildAudioRecord(encodingFormat, sampleRate, bufferSizeBytes)
-            track = buildAudioTrack(encodingFormat, sampleRate, bufferSizeBytes)
+            track = buildAudioTrack(
+                outputFormat,
+                bufferSize * bytesPerSample(outputFormat.encoding),
+            )
         }
         catch(ex: Exception) {
             Timber.e("Failed to create initial audio record/track")
@@ -465,6 +580,9 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
                 val floatOutBuffer = FloatArray(bufferSize)
                 val shortBuffer = ShortArray(bufferSize)
                 val shortOutBuffer = ShortArray(bufferSize)
+                val packedOutputBuffer = ByteBuffer
+                    .allocateDirect(bufferSize * Int.SIZE_BYTES)
+                    .order(ByteOrder.nativeOrder())
                 while (!isProcessorDisposing) {
                     if(recreateRecorderRequested) {
                         recreateRecorderRequested = false
@@ -519,12 +637,24 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
                     if(encoding == AudioEncoding.PcmShort) {
                         recorder.read(shortBuffer, 0, shortBuffer.size, AudioRecord.READ_BLOCKING)
                         engine.processInt16(shortBuffer, shortOutBuffer)
-                        track.write(shortOutBuffer, 0, shortOutBuffer.size, AudioTrack.WRITE_BLOCKING)
+                        writeShortOutput(
+                            track,
+                            outputFormat.encoding,
+                            shortOutBuffer,
+                            floatOutBuffer,
+                            packedOutputBuffer,
+                        )
                     }
                     else {
                         recorder.read(floatBuffer, 0, floatBuffer.size, AudioRecord.READ_BLOCKING)
                         engine.processFloat(floatBuffer, floatOutBuffer)
-                        track.write(floatOutBuffer, 0, floatOutBuffer.size, AudioTrack.WRITE_BLOCKING)
+                        writeFloatOutput(
+                            track,
+                            outputFormat.encoding,
+                            floatOutBuffer,
+                            shortOutBuffer,
+                            packedOutputBuffer,
+                        )
                     }
                 }
             } catch (e: IOException) {
@@ -573,42 +703,291 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
         startRecording()
     }
 
-    private fun buildAudioTrack(encoding: Int, sampleRate: Int, bufferSizeBytes: Int): AudioTrack {
-        val attributesBuilder = AudioAttributes.Builder()
-            .setUsage(AudioAttributes.USAGE_UNKNOWN)
-            .setContentType(AudioAttributes.CONTENT_TYPE_UNKNOWN)
-            .setFlags(0)
+    private fun restartForSampleRateChange(sampleRate: Int) {
+        if (!isRunning || engine.sampleRate.toInt() == sampleRate) return
 
-        sdkAbove(Build.VERSION_CODES.Q) {
-            attributesBuilder.setAllowedCapturePolicy(AudioAttributes.ALLOW_CAPTURE_BY_NONE)
+        Timber.i(
+            "Output sample rate changed from ${engine.sampleRate.toInt()}Hz to ${sampleRate}Hz"
+        )
+        restartRecording()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun registerPreferredMixerAttributesListener() {
+        preferredMixerAttributesListener =
+            AudioManager.OnPreferredMixerAttributesChangedListener {
+                    _: AudioAttributes,
+                    _: AudioDeviceInfo,
+                    _: AudioMixerAttributes? ->
+                restartForSampleRateChange(determineSamplingRate())
+            }
+        audioManager.addOnPreferredMixerAttributesChangedListener(
+            mainExecutor,
+            preferredMixerAttributesListener!!,
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun unregisterPreferredMixerAttributesListener() {
+        preferredMixerAttributesListener?.let {
+            audioManager.removeOnPreferredMixerAttributesChangedListener(it)
         }
+        preferredMixerAttributesListener = null
+    }
 
-        val format = AudioFormat.Builder()
+    private fun buildMediaAudioAttributes(): AudioAttributes {
+        return AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .build()
+    }
+
+    private fun isUsbAudioDevice(device: AudioDeviceInfo): Boolean {
+        return device.type == AudioDeviceInfo.TYPE_USB_DEVICE ||
+            device.type == AudioDeviceInfo.TYPE_USB_HEADSET ||
+            device.type == AudioDeviceInfo.TYPE_USB_ACCESSORY
+    }
+
+    private fun isUsbOutputConnected(): Boolean {
+        return audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).any(::isUsbAudioDevice)
+    }
+
+    private fun followUsbHardwareRate(): Boolean {
+        return preferences.get<String>(R.string.key_audioformat_rootless_usb_rate_mode) != "0"
+    }
+
+    private fun scheduleUsbHardwareRateReconfiguration() {
+        if (usbHardwareRateReconfigurationPending || !isRunning || !isUsbOutputConnected()) return
+        usbHardwareRateReconfigurationPending = true
+
+        // Release our own USB stream so AudioFlinger exposes the rate selected by the
+        // captured source application's remaining (silenced) hardware stream.
+        stopRecording()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            clearPreferredUsbMixer()
+        }
+        isProcessorDisposing = false
+
+        mainHandler.postDelayed({
+            applicationScope.launch(Dispatchers.IO) {
+                val hardwareRate = UsbHardwareSampleRateDetector.detect(
+                    this@RootlessAudioProcessorService
+                )
+                mainHandler.post {
+                    usbHardwareRateReconfigurationPending = false
+                    if (isServiceDisposing) return@post
+                    activeUsbHardwareSampleRate = hardwareRate
+                    startRecording()
+                }
+            }
+        }, USB_HARDWARE_RATE_SETTLE_DELAY_MS)
+    }
+
+    private fun buildOutputAudioFormat(encoding: Int, sampleRate: Int): AudioFormat {
+        return AudioFormat.Builder()
             .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
             .setEncoding(encoding)
             .setSampleRate(sampleRate)
             .build()
+    }
 
-        val frameSizeInBytes: Int = if (encoding == AudioFormat.ENCODING_PCM_16BIT) {
-            2 /* channels */ * 2 /* bytes */
-        } else {
-            2 /* channels */ * 4 /* bytes */
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun configurePreferredUsbMixer(
+        sampleRate: Int,
+        requestedEncoding: Int,
+    ): AudioFormat? {
+        clearPreferredUsbMixer()
+
+        val attributes = buildMediaAudioAttributes()
+        return try {
+            audioManager.getAudioDevicesForAttributes(attributes)
+                .filter(::isUsbAudioDevice)
+                .firstNotNullOfOrNull { device ->
+                    val mixer = audioManager.getSupportedMixerAttributes(device)
+                        .asSequence()
+                        .filter {
+                            it.format.sampleRate == sampleRate &&
+                                it.format.channelCount == 2 &&
+                                it.format.encoding in SUPPORTED_USB_OUTPUT_ENCODINGS
+                        }
+                        .sortedWith(
+                            compareByDescending<AudioMixerAttributes> {
+                                it.mixerBehavior ==
+                                    AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                            }.thenByDescending {
+                                it.format.encoding == requestedEncoding
+                            }.thenBy {
+                                usbEncodingPreference(it.format.encoding)
+                            }
+                        )
+                        .firstOrNull()
+                        ?: return@firstNotNullOfOrNull null
+
+                    if (!audioManager.setPreferredMixerAttributes(attributes, device, mixer)) {
+                        Timber.w("USB mixer rejected ${sampleRate}Hz")
+                        return@firstNotNullOfOrNull null
+                    }
+
+                    preferredUsbMixerDevice = device
+                    preferredUsbMixerAudioAttributes = attributes
+                    Timber.i(
+                        "Configured USB mixer at ${mixer.format.sampleRate}Hz, " +
+                            "encoding=${mixer.format.encoding}, " +
+                            "behavior=${mixer.mixerBehavior}"
+                    )
+                    mixer.format
+                }
+        } catch (exception: RuntimeException) {
+            Timber.w(exception, "Failed to configure preferred USB mixer")
+            null
         }
+    }
 
-        val bufferSize = if (((bufferSizeBytes % frameSizeInBytes) != 0 || bufferSizeBytes < 1)) {
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun clearPreferredUsbMixer() {
+        val device = preferredUsbMixerDevice
+        val attributes = preferredUsbMixerAudioAttributes
+        preferredUsbMixerDevice = null
+        preferredUsbMixerAudioAttributes = null
+        if (device == null || attributes == null) return
+
+        try {
+            audioManager.clearPreferredMixerAttributes(attributes, device)
+        } catch (exception: RuntimeException) {
+            Timber.w(exception, "Failed to clear preferred USB mixer")
+        }
+    }
+
+    private fun buildAudioTrack(format: AudioFormat, bufferSizeBytes: Int): AudioTrack {
+        val encoding = format.encoding
+        val sampleRate = format.sampleRate
+        val frameSizeInBytes = format.channelCount * bytesPerSample(encoding)
+
+        val requestedBufferSize = if (((bufferSizeBytes % frameSizeInBytes) != 0 || bufferSizeBytes < 1)) {
             Timber.e("Invalid audio buffer size $bufferSizeBytes")
             128 * (bufferSizeBytes / 128)
         }
         else bufferSizeBytes
+        val minimumBufferSize = AudioTrack.getMinBufferSize(
+            sampleRate,
+            format.channelMask,
+            encoding,
+        ).coerceAtLeast(0)
+        val bufferSize = maxOf(requestedBufferSize, minimumBufferSize)
+            .let { size ->
+                val remainder = size % frameSizeInBytes
+                if (remainder == 0) size else size + frameSizeInBytes - remainder
+            }
 
         Timber.d("Using buffer size $bufferSize")
 
         return AudioTrack.Builder()
             .setAudioFormat(format)
             .setTransferMode(AudioTrack.MODE_STREAM)
-            .setAudioAttributes(attributesBuilder.build())
+            .setAudioAttributes(buildMediaAudioAttributes())
             .setBufferSizeInBytes(bufferSize)
             .build()
+    }
+
+    private fun writeFloatOutput(
+        track: AudioTrack,
+        outputEncoding: Int,
+        samples: FloatArray,
+        shortBuffer: ShortArray,
+        packedBuffer: ByteBuffer,
+    ) {
+        when (outputEncoding) {
+            AudioFormat.ENCODING_PCM_FLOAT ->
+                track.write(samples, 0, samples.size, AudioTrack.WRITE_BLOCKING)
+            AudioFormat.ENCODING_PCM_16BIT -> {
+                samples.indices.forEach { index ->
+                    shortBuffer[index] = floatToPcm16(samples[index])
+                }
+                track.write(shortBuffer, 0, shortBuffer.size, AudioTrack.WRITE_BLOCKING)
+            }
+            AudioFormat.ENCODING_PCM_24BIT_PACKED,
+            AudioFormat.ENCODING_PCM_32BIT -> {
+                packedBuffer.clear()
+                samples.forEach { sample -> putPcmSample(packedBuffer, outputEncoding, sample) }
+                packedBuffer.flip()
+                track.write(packedBuffer, packedBuffer.remaining(), AudioTrack.WRITE_BLOCKING)
+            }
+            else -> error("Unsupported USB output encoding $outputEncoding")
+        }
+    }
+
+    private fun writeShortOutput(
+        track: AudioTrack,
+        outputEncoding: Int,
+        samples: ShortArray,
+        floatBuffer: FloatArray,
+        packedBuffer: ByteBuffer,
+    ) {
+        when (outputEncoding) {
+            AudioFormat.ENCODING_PCM_16BIT ->
+                track.write(samples, 0, samples.size, AudioTrack.WRITE_BLOCKING)
+            AudioFormat.ENCODING_PCM_FLOAT -> {
+                samples.indices.forEach { index ->
+                    floatBuffer[index] = samples[index] / 32768f
+                }
+                track.write(floatBuffer, 0, floatBuffer.size, AudioTrack.WRITE_BLOCKING)
+            }
+            AudioFormat.ENCODING_PCM_24BIT_PACKED,
+            AudioFormat.ENCODING_PCM_32BIT -> {
+                packedBuffer.clear()
+                samples.forEach { sample ->
+                    putPcmSample(packedBuffer, outputEncoding, sample / 32768f)
+                }
+                packedBuffer.flip()
+                track.write(packedBuffer, packedBuffer.remaining(), AudioTrack.WRITE_BLOCKING)
+            }
+            else -> error("Unsupported USB output encoding $outputEncoding")
+        }
+    }
+
+    private fun putPcmSample(buffer: ByteBuffer, encoding: Int, value: Float) {
+        val normalized = value.coerceIn(-1f, 1f)
+        when (encoding) {
+            AudioFormat.ENCODING_PCM_32BIT -> {
+                val pcm = if (normalized <= -1f) Int.MIN_VALUE
+                else (normalized * Int.MAX_VALUE).toInt()
+                buffer.putInt(pcm)
+            }
+            AudioFormat.ENCODING_PCM_24BIT_PACKED -> {
+                val pcm = if (normalized <= -1f) -0x800000
+                else (normalized * 0x7fffff).toInt()
+                if (buffer.order() == ByteOrder.LITTLE_ENDIAN) {
+                    buffer.put(pcm.toByte())
+                    buffer.put((pcm shr 8).toByte())
+                    buffer.put((pcm shr 16).toByte())
+                } else {
+                    buffer.put((pcm shr 16).toByte())
+                    buffer.put((pcm shr 8).toByte())
+                    buffer.put(pcm.toByte())
+                }
+            }
+        }
+    }
+
+    private fun floatToPcm16(value: Float): Short {
+        val normalized = value.coerceIn(-1f, 1f)
+        return if (normalized <= -1f) Short.MIN_VALUE
+        else (normalized * Short.MAX_VALUE).toInt().toShort()
+    }
+
+    private fun bytesPerSample(encoding: Int): Int = when (encoding) {
+        AudioFormat.ENCODING_PCM_16BIT -> Short.SIZE_BYTES
+        AudioFormat.ENCODING_PCM_24BIT_PACKED -> 3
+        AudioFormat.ENCODING_PCM_FLOAT,
+        AudioFormat.ENCODING_PCM_32BIT -> Int.SIZE_BYTES
+        else -> error("Unsupported USB output encoding $encoding")
+    }
+
+    private fun usbEncodingPreference(encoding: Int): Int = when (encoding) {
+        AudioFormat.ENCODING_PCM_FLOAT -> 0
+        AudioFormat.ENCODING_PCM_32BIT -> 1
+        AudioFormat.ENCODING_PCM_24BIT_PACKED -> 2
+        AudioFormat.ENCODING_PCM_16BIT -> 3
+        else -> Int.MAX_VALUE
     }
 
     @SuppressLint("MissingPermission")
@@ -623,6 +1002,12 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
             .setSampleRate(sampleRate)
             .setChannelMask(AudioFormat.CHANNEL_IN_STEREO)
             .build()
+        val minimumBufferSize = AudioRecord.getMinBufferSize(
+            sampleRate,
+            AudioFormat.CHANNEL_IN_STEREO,
+            encoding,
+        ).coerceAtLeast(0)
+        val recordBufferSize = maxOf(bufferSizeBytes, minimumBufferSize)
 
         val configBuilder = AudioPlaybackCaptureConfiguration.Builder(mediaProjection!!)
             .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
@@ -649,17 +1034,76 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
 
         return AudioRecord.Builder()
             .setAudioFormat(format)
-            .setBufferSizeInBytes(bufferSizeBytes)
+            .setBufferSizeInBytes(recordBufferSize)
             .setAudioPlaybackCaptureConfig(configBuilder.build())
             .build()
     }
 
     // Determine HAL sampling rate
     private fun determineSamplingRate(): Int {
-        val sampleRateStr: String? = audioManager.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
-        val srate = sampleRateStr?.let { str -> Integer.parseInt(str).takeUnless { it == 0 } } ?: 48000
+        if (isUsbOutputConnected() && followUsbHardwareRate()) {
+            activeUsbHardwareSampleRate
+                .takeIf(AudioSampleRateDetector::isSupportedProcessingRate)
+                ?.let { hardwareRate ->
+                    Timber.i("Using physical USB sampling rate $hardwareRate")
+                    return hardwareRate
+                }
+
+            UsbHardwareSampleRateDetector.detect(this)
+                .takeIf(AudioSampleRateDetector::isSupportedProcessingRate)
+                ?.let { hardwareRate ->
+                    activeUsbHardwareSampleRate = hardwareRate
+                    Timber.i("Using detected physical USB sampling rate $hardwareRate")
+                    return hardwareRate
+                }
+        }
+
+        activeContentSampleRate
+            .takeIf(AudioSampleRateDetector::isSupportedProcessingRate)
+            ?.let { contentRate ->
+                Timber.i("Using active content sampling rate $contentRate")
+                return contentRate
+            }
+
+        val srate = AudioSampleRateDetector.getActiveOutputSampleRate(audioManager)
         Timber.i("Real HAL sampling rate is $srate")
         return srate
+    }
+
+    private fun detectActiveContentSampleRate(
+        configs: Collection<AudioPlaybackConfiguration>?,
+    ): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return 0
+
+        return configs.orEmpty().mapNotNull { config ->
+            try {
+                val hidden = Refine.unsafeCast<AudioPlaybackConfigurationHidden>(config)
+                val usage = config.audioAttributes.usage
+                val capturedUsage = usage == AudioAttributes.USAGE_MEDIA ||
+                    usage == AudioAttributes.USAGE_GAME ||
+                    usage == AudioAttributes.USAGE_UNKNOWN
+                hidden.getSampleRate().takeIf { rate ->
+                    hidden.isActive() &&
+                        hidden.getClientUid() != Process.myUid() &&
+                        capturedUsage &&
+                        AudioSampleRateDetector.isSupportedProcessingRate(rate)
+                }
+            } catch (exception: Throwable) {
+                Timber.w(exception, "Failed to read active playback sample rate")
+                null
+            }
+        }.maxOrNull() ?: 0
+    }
+
+    private fun applyActiveContentSampleRate(detectedRate: Int) {
+        if (activeContentSampleRate != detectedRate) {
+            Timber.i(
+                "Active content sample rate changed from " +
+                    "${activeContentSampleRate}Hz to ${detectedRate}Hz"
+            )
+            activeContentSampleRate = detectedRate
+        }
+        restartForSampleRateChange(determineSamplingRate())
     }
 
     // Determine HAL buffer size
@@ -669,6 +1113,15 @@ class RootlessAudioProcessorService : BaseAudioProcessorService() {
     }
 
     companion object {
+        private val SUPPORTED_USB_OUTPUT_ENCODINGS = setOf(
+            AudioFormat.ENCODING_PCM_FLOAT,
+            AudioFormat.ENCODING_PCM_32BIT,
+            AudioFormat.ENCODING_PCM_24BIT_PACKED,
+            AudioFormat.ENCODING_PCM_16BIT,
+        )
+        private const val USB_ROUTE_SETTLE_DELAY_MS = 750L
+        private const val USB_HARDWARE_RATE_SETTLE_DELAY_MS = 500L
+
         const val SESSION_LOSS_MAX_RETRIES = 1
 
         const val ACTION_START = BuildConfig.APPLICATION_ID + ".rootless.service.START"

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/ActivePlaybackSampleRateDetector.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/ActivePlaybackSampleRateDetector.kt
@@ -1,0 +1,48 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import android.content.Context
+import me.timschneeberger.rootlessjamesdsp.session.dump.provider.AudioServiceDumpProvider
+import me.timschneeberger.rootlessjamesdsp.session.dump.utils.DumpUtils
+import timber.log.Timber
+
+object ActivePlaybackSampleRateDetector {
+    private val uidRegex = """u/pid:(\d+)/(\d+)""".toRegex()
+    private val usageRegex = """usage=(\w+)""".toRegex()
+    private val sampleRateRegex = """sampleRate=(\d+)""".toRegex()
+    private val playbackConfigurationRegex = Regex(
+        """AudioPlaybackConfiguration.*?(?=\n\s*AudioPlaybackConfiguration|\z)""",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+    private val capturedUsages = setOf("USAGE_MEDIA", "USAGE_GAME", "USAGE_UNKNOWN")
+
+    fun detect(context: Context, excludedUid: Int): Int {
+        val dump = DumpUtils.dumpAll(context, AudioServiceDumpProvider.TARGET_SERVICE)
+            ?: return 0
+        return parse(dump, excludedUid)
+    }
+
+    internal fun parse(dump: String, excludedUid: Int): Int {
+        return playbackConfigurationRegex.findAll(dump).mapNotNull { match ->
+            val configuration = match.value
+            if (!configuration.contains("state:started")) {
+                return@mapNotNull null
+            }
+
+            val uid = uidRegex.find(configuration)?.groupValues?.getOrNull(1)?.toIntOrNull()
+                ?: return@mapNotNull null
+            val usage = usageRegex.find(configuration)?.groupValues?.getOrNull(1)
+                ?: return@mapNotNull null
+            val sampleRate = sampleRateRegex.find(configuration)
+                ?.groupValues?.getOrNull(1)?.toIntOrNull()
+                ?: return@mapNotNull null
+
+            sampleRate.takeIf {
+                uid != excludedUid &&
+                    usage in capturedUsages &&
+                    AudioSampleRateDetector.isSupportedProcessingRate(it)
+            }
+        }.maxOrNull().also {
+            Timber.d("Audio service dump active content sample rate: ${it ?: 0}Hz")
+        } ?: 0
+    }
+}

--- a/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/UsbHardwareSampleRateDetector.kt
+++ b/app/src/main/java/me/timschneeberger/rootlessjamesdsp/utils/UsbHardwareSampleRateDetector.kt
@@ -1,0 +1,42 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import android.content.Context
+import me.timschneeberger.rootlessjamesdsp.session.dump.utils.DumpUtils
+import timber.log.Timber
+
+/** Reads the physical PCM rate of the active USB output from AudioFlinger. */
+object UsbHardwareSampleRateDetector {
+    private const val AUDIO_FLINGER_SERVICE = "media.audio_flinger"
+    private val outputThreadRegex = Regex(
+        """Output thread .*?(?=\nOutput thread |\z)""",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+    private val pcmConfigRateRegex = """output pcm config sample rate:\s*(\d+)""".toRegex()
+    private val activeTracksRegex = """(\d+) Tracks of which (\d+) are active""".toRegex()
+
+    fun detect(context: Context): Int {
+        return DumpUtils.dumpAll(context, AUDIO_FLINGER_SERVICE)
+            ?.let(::parse)
+            ?: 0
+    }
+
+    internal fun parse(dump: String): Int {
+        return outputThreadRegex.findAll(dump).mapNotNull { match ->
+            val thread = match.value
+            val isUsb = thread.contains("AUDIO_DEVICE_OUT_USB_DEVICE") ||
+                thread.contains("AUDIO_DEVICE_OUT_USB_HEADSET") ||
+                thread.contains("AUDIO_DEVICE_OUT_USB_ACCESSORY")
+            val activeTrackCount = activeTracksRegex.find(thread)
+                ?.groupValues?.getOrNull(2)?.toIntOrNull()
+                ?: 0
+            if (!isUsb || thread.contains("Standby: yes") || activeTrackCount == 0) {
+                return@mapNotNull null
+            }
+
+            pcmConfigRateRegex.find(thread)?.groupValues?.getOrNull(1)?.toIntOrNull()
+                ?.takeIf(AudioSampleRateDetector::isSupportedProcessingRate)
+        }.maxOrNull().also {
+            Timber.i("Active physical USB sample rate: ${it ?: 0}Hz")
+        } ?: 0
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -65,6 +65,16 @@
         <item>1</item>
     </string-array>
 
+    <string-array name="audio_format_rootless_usb_rate_modes" translatable="false">
+        <item>@string/audio_format_rootless_usb_rate_hardware</item>
+        <item>@string/audio_format_rootless_usb_rate_source</item>
+    </string-array>
+
+    <string-array name="audio_format_rootless_usb_rate_mode_values" translatable="false">
+        <item>1</item>
+        <item>0</item>
+    </string-array>
+
     <string-array name="reverb_presets" translatable="false">
         <item>@string/reverb_preset_default</item>
         <item>@string/reverb_preset_small_hall1</item>

--- a/app/src/main/res/values/defaults.xml
+++ b/app/src/main/res/values/defaults.xml
@@ -32,6 +32,7 @@
     <bool name="default_autostart_prompt_at_boot" translatable="false">true</bool>
     <bool name="default_powersave_suspend" translatable="false">true</bool>
     <string name="default_audioformat_encoding" translatable="false">1</string>
+    <string name="default_audioformat_rootless_usb_rate_mode" translatable="false">1</string>
     <integer name="default_audioformat_buffersize" translatable="false">8192</integer>
     <bool name="default_audioformat_processing" translatable="false">true</bool>
     <bool name="default_audioformat_enhanced_processing" translatable="false">false</bool>

--- a/app/src/main/res/values/keys.xml
+++ b/app/src/main/res/values/keys.xml
@@ -39,6 +39,7 @@
     <string name="key_powersave_suspend" translatable="false">powersave_suspend</string>
     <string name="key_audioformat_encoding" translatable="false">audioformat_encoding</string>
     <string name="key_audioformat_buffersize" translatable="false">audioformat_buffersize</string>
+    <string name="key_audioformat_rootless_usb_rate_mode" translatable="false">audioformat_rootless_usb_rate_mode</string>
     <string name="key_audioformat_processing" translatable="false">audioformat_processing</string>
     <string name="key_audioformat_enhanced_processing" translatable="false">audioformat_enhanced_processing</string>
     <string name="key_audioformat_optimization_benchmark" translatable="false">audioformat_optimization_benchmark</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -366,6 +366,9 @@
     <string name="audio_format_encoding">Audio encoding</string>
     <string name="audio_format_encoding_int16">16-bit integer PCM</string>
     <string name="audio_format_encoding_float">32-bit float PCM</string>
+    <string name="audio_format_rootless_usb_rate_mode">Rootless USB processing rate</string>
+    <string name="audio_format_rootless_usb_rate_hardware">Follow USB hardware rate</string>
+    <string name="audio_format_rootless_usb_rate_source">Follow source rate (allow Android conversion)</string>
     <string name="audio_format_buffer_size">Buffer size</string>
     <string name="audio_format_buffer_size_unit">&#xa0;samples</string>
     <string name="audio_format_buffer_size_warning_low_value">Warning: Low buffer sizes may cause audio issues such as clipping!</string>

--- a/app/src/main/res/xml/app_audio_format_preferences.xml
+++ b/app/src/main/res/xml/app_audio_format_preferences.xml
@@ -10,6 +10,14 @@
             app:useSimpleSummaryProvider="true"
             app:defaultValue="@string/default_audioformat_encoding"
             app:iconSpaceReserved="false" />
+        <ListPreference
+            app:key="@string/key_audioformat_rootless_usb_rate_mode"
+            app:title="@string/audio_format_rootless_usb_rate_mode"
+            app:entries="@array/audio_format_rootless_usb_rate_modes"
+            app:entryValues="@array/audio_format_rootless_usb_rate_mode_values"
+            app:useSimpleSummaryProvider="true"
+            app:defaultValue="@string/default_audioformat_rootless_usb_rate_mode"
+            app:iconSpaceReserved="false" />
         <me.timschneeberger.rootlessjamesdsp.preference.MaterialSeekbarPreference
             android:key="@string/key_audioformat_buffersize"
             android:title="@string/audio_format_buffer_size"

--- a/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/ActivePlaybackSampleRateDetectorTest.kt
+++ b/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/ActivePlaybackSampleRateDetectorTest.kt
@@ -1,0 +1,51 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ActivePlaybackSampleRateDetectorTest {
+    @Test
+    fun `reads active external media sample rate`() {
+        val dump = """
+            AudioPlaybackConfiguration piid:10 deviceId:7 type:android.media.AudioTrack u/pid:10123/456 state:started attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:12 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=96000}
+        """.trimIndent()
+
+        assertEquals(96_000, ActivePlaybackSampleRateDetector.parse(dump, 10001))
+    }
+
+    @Test
+    fun `reads Samsung wrapped playback configuration`() {
+        val dump = """
+            AudioPlaybackConfiguration piid:10 deviceId:788 type:android.media.AudioTrack u/pid:10123/456 state:started
+            attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:12 mutedState:none
+            FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=96000}
+            AudioPlaybackConfiguration piid:11 deviceId:788 type:android.media.AudioTrack u/pid:10001/457 state:started
+            attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_UNKNOWN flags=0x0 sessionId:13 mutedState:none
+            FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=96000}
+        """.trimIndent()
+
+        assertEquals(96_000, ActivePlaybackSampleRateDetector.parse(dump, 10001))
+    }
+
+    @Test
+    fun `ignores own paused and non captured players`() {
+        val dump = """
+            AudioPlaybackConfiguration piid:10 deviceId:7 type:android.media.AudioTrack u/pid:10001/456 state:started attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:12 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=192000}
+            AudioPlaybackConfiguration piid:11 deviceId:7 type:android.media.AudioTrack u/pid:10123/457 state:paused attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:13 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=96000}
+            AudioPlaybackConfiguration piid:12 deviceId:7 type:android.media.AudioTrack u/pid:10124/458 state:started attr:AudioAttributes: usage=USAGE_NOTIFICATION content=CONTENT_TYPE_SONIFICATION flags=0x0 sessionId:14 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=48000}
+        """.trimIndent()
+
+        assertEquals(0, ActivePlaybackSampleRateDetector.parse(dump, 10001))
+    }
+
+    @Test
+    fun `selects highest active captured rate through 384 kHz`() {
+        val dump = """
+            AudioPlaybackConfiguration piid:10 deviceId:7 type:android.media.AudioTrack u/pid:10123/456 state:started attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:12 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=88200}
+            AudioPlaybackConfiguration piid:11 deviceId:7 type:AAudio u/pid:10124/457 state:started attr:AudioAttributes: usage=USAGE_GAME content=CONTENT_TYPE_UNKNOWN flags=0x0 sessionId:13 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=192000}
+            AudioPlaybackConfiguration piid:12 deviceId:7 type:AAudio u/pid:10125/458 state:started attr:AudioAttributes: usage=USAGE_MEDIA content=CONTENT_TYPE_MUSIC flags=0x0 sessionId:14 mutedState:none FormatInfo{isSpatialized=false, channelMask=0x3, sampleRate=384000}
+        """.trimIndent()
+
+        assertEquals(384_000, ActivePlaybackSampleRateDetector.parse(dump, 10001))
+    }
+}

--- a/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/UsbHardwareSampleRateDetectorTest.kt
+++ b/app/src/test/java/me/timschneeberger/rootlessjamesdsp/utils/UsbHardwareSampleRateDetectorTest.kt
@@ -1,0 +1,38 @@
+package me.timschneeberger.rootlessjamesdsp.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UsbHardwareSampleRateDetectorTest {
+    @Test
+    fun `reads active physical USB pcm rate`() {
+        val dump = """
+            Output thread 0x1, name AudioOut_15, tid 1, type 0 (MIXER):
+              Standby: no
+              Sample rate: 48000 Hz
+              Output devices: 0x4000000 (AUDIO_DEVICE_OUT_USB_HEADSET)
+              output pcm config sample rate: 192000
+              1 Tracks of which 1 are active
+            Output thread 0x2, name AudioOut_D, tid 2, type 0 (MIXER):
+              Standby: no
+              Sample rate: 48000 Hz
+              Output devices: 0x2 (AUDIO_DEVICE_OUT_SPEAKER)
+              1 Tracks of which 1 are active
+        """.trimIndent()
+
+        assertEquals(192_000, UsbHardwareSampleRateDetector.parse(dump))
+    }
+
+    @Test
+    fun `ignores standby and inactive USB threads`() {
+        val dump = """
+            Output thread 0x1, name AudioOut_15, tid 1, type 0 (MIXER):
+              Standby: yes
+              Output devices: 0x4000000 (AUDIO_DEVICE_OUT_USB_HEADSET)
+              output pcm config sample rate: 192000
+              1 Tracks of which 0 are active
+        """.trimIndent()
+
+        assertEquals(0, UsbHardwareSampleRateDetector.parse(dump))
+    }
+}

--- a/hidden-api-refined/src/main/java/android/media/AudioPlaybackConfigurationHidden.java
+++ b/hidden-api-refined/src/main/java/android/media/AudioPlaybackConfigurationHidden.java
@@ -28,4 +28,14 @@ public class AudioPlaybackConfigurationHidden {
     public int getSessionId() {
         throw new RuntimeException("Stub!");
     }
+
+    /** Return whether the corresponding player is actively playing. */
+    public boolean isActive() {
+        throw new RuntimeException("Stub!");
+    }
+
+    /** Return the sample rate in Hz of the content being played. */
+    public int getSampleRate() {
+        throw new RuntimeException("Stub!");
+    }
 }


### PR DESCRIPTION
## Draft / dependency

This is stacked on and depends on #337. Until that PR merges, GitHub shows both commits here. The dynamic rootless-rate work is the second commit (`03cbbba`).

## Summary

Allow rootless processing to follow active source or physical USB hardware sample rates instead of clamping processing to 44.1/48 kHz.

Adds two USB modes:
- **Follow USB hardware rate:** rebuild processing at the physical output rate.
- **Follow source rate:** process at the source rate and allow Android to perform final conversion.

## Implementation

- detects active playback source rates
- tracks route changes and rebuilds AudioRecord/AudioTrack as needed
- uses Android 14 preferred mixer attributes where available
- exposes source, processing, and hardware rates separately
- supports processing rates through 384 kHz
- preserves safe fallbacks when detection fails

## Platform caveats

Some rate discovery relies on hidden playback configuration fields and AudioFlinger diagnostic output because rootless Android does not expose the complete physical path through a stable public API. This is why the PR is opened as a draft for design feedback.

## Testing

- all 16 rootless F-Droid unit tests pass
- rootless debug APK builds successfully
- tested on a Samsung device with a FiiO BTR7 USB DAC
- verified a 96 kHz JamesDSP processing path, 96 kHz Android A2DP output, and LDAC negotiated at 96 kHz/24-bit
